### PR TITLE
[demo] - Correct wrong function call

### DIFF
--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -91,7 +91,7 @@ view { autocompleteState, quote } =
       [ Autocomplete.defaultAttributes
         |> Autocomplete.withPlaceholder "Type some Chuck Norris related terms like 'plane' or 'truck'"
         |> Autocomplete.withHover [ ("background-color", "grey") ]
-        |> Autocomplete.input autocompleteState cellView
+        |> Autocomplete.view autocompleteState cellView
       , case quote of
         Nothing ->
           Html.text ""


### PR DESCRIPTION
Hi @ghivert :)

First of all, thanks for the time you’ve taken to extract and publish this autocomplete, greatly appreciate it :+1: :muscle: 

Here a quick fix for the demo:

The demo was using `Autocomplete.input` function but my guess is that this function was renamed to `Autocomplete.view` in some refacto